### PR TITLE
서치 기능, 카테고리 클릭 기능 백-프론트 통신 완료(ui는 미완성)

### DIFF
--- a/frontend/src/components/search/search.css
+++ b/frontend/src/components/search/search.css
@@ -1,0 +1,25 @@
+.searchBar{
+    display:flex;
+    justify-content: space-between;
+    align-items: center;
+    border:1px solid #ccc;
+    background-color: rgb(184, 182, 182);
+    margin: 0 auto;
+    width:600px;
+    border-radius: 10px;
+    margin-bottom:50px;
+}
+
+.searchBar input{
+    border:none;
+    outline:none;
+    background:rgb(184, 182, 182);
+    font-size:16px;
+    flex-grow:1;
+    padding:10px;
+}
+.searchBar div{
+    font-size:20px;
+    color:gray;
+    cursor:pointer;
+}

--- a/frontend/src/components/search/search.jsx
+++ b/frontend/src/components/search/search.jsx
@@ -1,0 +1,51 @@
+import './search.css'
+import {React,useState} from 'react'
+
+
+export default function Search() {
+
+    const [text,setText]=useState('');
+    const [result,setResult]=useState('');
+    const [show,setShow]=useState(false);
+
+    const url="http://localhost/3000";//express.js 포트 변경 예정
+    const headers='';//회원 로직 나중에 추가예정
+
+    const searchBar = async ()=>{
+        setShow(true)
+        const search=await axios.get(url+`/?value=${text}`);
+        setResult(search);
+    }
+
+    const close =()=>{
+        setShow(false)
+        setText('');
+    }
+
+
+  return (
+    <div>
+        <div className="searchBar">
+                <input type="text" placeholder="지역, 음식 또는 식당명 입력" onChange={(e)=>setText(e.target.value)}>
+                </input>
+                <div onClick={searchBar}>
+                🔍
+                </div>
+        </div>
+
+        {
+            show&&(result?<div>
+                    앗! 결과값이 나왔습니다. 결과값은? {result}입니다!
+                    <button>상세페이지로 이동하기</button>
+                    <button onClick={close}>X</button>
+                </div>
+            :
+            <div>
+                검색 결과가 안나옵니다!
+            </div>)
+            
+        }
+        
+    </div>
+  )
+}

--- a/frontend/src/components/search/search.jsx
+++ b/frontend/src/components/search/search.jsx
@@ -1,6 +1,6 @@
 import './search.css'
 import {React,useState} from 'react'
-
+import axios from 'axios';
 
 export default function Search() {
 
@@ -8,13 +8,20 @@ export default function Search() {
     const [result,setResult]=useState('');
     const [show,setShow]=useState(false);
 
-    const url="http://localhost/3000";//express.js 포트 변경 예정
+    const url="http://localhost:5000/search/api/data";//express.js 포트 변경 예정
     const headers='';//회원 로직 나중에 추가예정
 
-    const searchBar = async ()=>{
+    
+    const searchBar = ()=>{
         setShow(true)
-        const search=await axios.get(url+`/?value=${text}`);
-        setResult(search);
+        console.log(url)
+        axios.get(url+`?value=${text}`).then((response)=>{
+            setResult(response.data.result[0]);
+            
+        }
+        )
+        
+        
     }
 
     const close =()=>{
@@ -35,7 +42,9 @@ export default function Search() {
 
         {
             show&&(result?<div>
-                    앗! 결과값이 나왔습니다. 결과값은? {result}입니다!
+                            앗 찾았습니다! 결과값은? {result.name}입니다!
+
+                            
                     <button>상세페이지로 이동하기</button>
                     <button onClick={close}>X</button>
                 </div>

--- a/frontend/src/components/sort/sort.jsx
+++ b/frontend/src/components/sort/sort.jsx
@@ -1,9 +1,10 @@
 import {React,useEffect,useState} from 'react'
+import axios from "axios";
+export default function Sort() {
 
-export default function sort() {
+    const [data, setData] = useState([]);
+    const [show, setShow] = useState(false);
 
-    const [data,setData]=useState([])
-    const [show,setShow]=useSTate('')
 
     const all=async ()=>{
       const allitems=await axios.get("/sort");
@@ -30,7 +31,7 @@ export default function sort() {
     const japanese=async()=>{
       const japanese=await axios.get("/sort/japanese")
       setShow(true)
-      setData(japanese)
+      setData(japanese.data)
     }
     
     const desert=async()=>{
@@ -60,13 +61,13 @@ export default function sort() {
         setShow &&(
           <div>
 
-            data.map((elem,index)=>{
-              <div key={index+1} onClick={()=>UseNavigate()}> 
+            {data.map((elem,index)=>(
+              <div key={index+1} > 
               <img src={elem.imglink}></img>
               {elem.name}
               {elem.category}
               </div>
-            })
+            ))}
 
 
             </div>

--- a/frontend/src/components/sort/sort.jsx
+++ b/frontend/src/components/sort/sort.jsx
@@ -4,56 +4,92 @@ export default function Sort() {
 
     const [data, setData] = useState([]);
     const [show, setShow] = useState(false);
+    const [randomindex,setrandomindex]=useState([]);
+
+    const random =(length)=>{
+      return parseInt(Math.random()*length)
+    }
+    const limitedRandomNumbers=(data)=>{
+      const randomNumbers=[];
+      for (let i=0;i<=5;i++){
+        randomNumbers.push(random(data.length));
+      }
+      return randomNumbers;
+    }
+
+    const full=(data)=>{
+      if (data.length>=5){
+        const random=limitedRandomNumbers(data);
+        const new_data = data.filter((elem, index) => random.includes(index));
+        setData(new_data)
+      }
+      else{
+        setData(data);
+      }
+    }
 
 
     const all=async ()=>{
       const allitems=await axios.get("http://localhost:5000/sort");
       setShow(true)
-      setData(allitems.data)
+      const temp=allitems.data;
+      full(temp);
     }
 
     const jjim=()=>{
+
+      
+
+      
 
     }
     
     const western=async ()=>{
       const western=await axios.get("http://localhost:5000/sort/western")
       setShow(true)
-      setData(western.data)
+      const temp=western.data;
+      full(temp);
     }
     
     const korea=async ()=>{
       const korea=await axios.get("http://localhost:5000/sort/korea")
       setShow(true)
-      setData(korea.data)
+      const temp=korea.data;
+      full(temp);
     }
     
     const japanese=async()=>{
       const japanese=await axios.get("http://localhost:5000/sort/japanese")
       setShow(true)
-      setData(japanese.data)
+      const temp=japanese.data;
+      full(temp);
     }
     
     const desert=async()=>{
       const desert=await axios.get("http://localhost:5000/sort/desert")
       setShow(true)
-      setData(desert.data)
+      const temp=desert.data;
+      full(temp);
     }
     const fastfood=async ()=>{
       const fastfood=await axios.get("http://localhost:5000/sort/fast-food")
       setShow(true)
-      setData(fastfood.data)
+      const temp=fastfood.data;
+      full(temp);
     }
     const flour=async ()=>{
       const flour=await axios.get("http://localhost:5000/sort/flour")
       setShow(true)
-      setData(flour.data)
+      const temp=flour.data;
+      full(temp);
     }
     const etc=async ()=>{
       const etc=await axios.get("http://localhost:5000/sort/etc")
       setShow(true)
-      setData(etc.data)
+      const temp=etc.data;
+      full(temp);
     }
+    
    
     
   return (
@@ -72,9 +108,6 @@ export default function Sort() {
       {
         setShow &&(
           <div>
-            {
-              data.length
-            }
             {data.map((elem,index)=>(
               <div key={index+1} > 
               <img src={elem.imglink}></img>

--- a/frontend/src/components/sort/sort.jsx
+++ b/frontend/src/components/sort/sort.jsx
@@ -7,7 +7,7 @@ export default function Sort() {
 
 
     const all=async ()=>{
-      const allitems=await axios.get("/sort");
+      const allitems=await axios.get("http://localhost:5000/sort");
       setShow(true)
       setData(allitems.data)
     }
@@ -17,32 +17,42 @@ export default function Sort() {
     }
     
     const western=async ()=>{
-      const western=await axios.get("/sort/western")
+      const western=await axios.get("http://localhost:5000/sort/western")
       setShow(true)
       setData(western.data)
     }
     
     const korea=async ()=>{
-      const korea=await axios.get("/sort/korea")
+      const korea=await axios.get("http://localhost:5000/sort/korea")
       setShow(true)
       setData(korea.data)
     }
     
     const japanese=async()=>{
-      const japanese=await axios.get("/sort/japanese")
+      const japanese=await axios.get("http://localhost:5000/sort/japanese")
       setShow(true)
       setData(japanese.data)
     }
     
     const desert=async()=>{
-      const desert=await axios.get("/sort/desert")
+      const desert=await axios.get("http://localhost:5000/sort/desert")
       setShow(true)
       setData(desert.data)
     }
     const fastfood=async ()=>{
-      const fastfood=await axios.get("/sort/fastfood")
+      const fastfood=await axios.get("http://localhost:5000/sort/fast-food")
       setShow(true)
       setData(fastfood.data)
+    }
+    const flour=async ()=>{
+      const flour=await axios.get("http://localhost:5000/sort/flour")
+      setShow(true)
+      setData(flour.data)
+    }
+    const etc=async ()=>{
+      const etc=await axios.get("http://localhost:5000/sort/etc")
+      setShow(true)
+      setData(etc.data)
     }
    
     
@@ -55,12 +65,16 @@ export default function Sort() {
                     <div onClick={korea}>한식</div>
                     <div onClick={japanese}>일식</div>
                     <div onClick={desert}>디저트</div>
+                    <div onClick={flour}>분식</div>
+                    <div onClick={etc}>기타</div>
                     <div onClick={fastfood}>패스트푸드</div>
       </div>
       {
         setShow &&(
           <div>
-
+            {
+              data.length
+            }
             {data.map((elem,index)=>(
               <div key={index+1} > 
               <img src={elem.imglink}></img>

--- a/frontend/src/components/sort/sort.jsx
+++ b/frontend/src/components/sort/sort.jsx
@@ -1,0 +1,78 @@
+import {React,useEffect,useState} from 'react'
+
+export default function sort() {
+
+    const [data,setData]=useState([])
+    const [show,setShow]=useSTate('')
+
+    const all=async ()=>{
+      const allitems=await axios.get("/sort");
+      setShow(true)
+      return allitems;
+    }
+
+    const jjim=()=>{
+
+    }
+    
+    const western=async ()=>{
+      const western=await axios.get("/sort/western")
+      setShow(true)
+      return western
+    }
+    
+    const korea=async ()=>{
+      const western=await axios.get("/sort/western")
+      setShow(true)
+      return western
+    }
+    
+    const japanese=async()=>{
+      const japanese=await axios.get("/sort/japanese")
+      setShow(true)
+      setData(japanese)
+    }
+    
+    const desert=async()=>{
+      const desert=await axios.get("/sort/desert")
+      setShow(true)
+      setData(desert)
+    }
+    const fastfood=async ()=>{
+      const fastfood=await axios.get("/sort/fastfood")
+      setShow(true)
+      setData(fastfood)
+    }
+   
+    
+  return (
+    <div>
+      <div className="category">
+                    <div onClick={all}>전체</div>
+                    <div onClick={jjim}>찜</div>
+                    <div onClick={western}>양식</div>
+                    <div onClick={korea}>한식</div>
+                    <div onClick={japanese}>일식</div>
+                    <div onClick={desert}>디저트</div>
+                    <div onClick={fastfood}>패스트푸드</div>
+      </div>
+      {
+        setShow &&(
+          <div>
+
+            data.map((elem,index)=>{
+              <div key={index+1} onClick={()=>UseNavigate()}> 
+              <img src={elem.imglink}></img>
+              {elem.name}
+              {elem.category}
+              </div>
+            })
+
+
+            </div>
+        )
+      }
+      
+    </div>
+  )
+}

--- a/frontend/src/components/sort/sort.jsx
+++ b/frontend/src/components/sort/sort.jsx
@@ -9,7 +9,7 @@ export default function Sort() {
     const all=async ()=>{
       const allitems=await axios.get("/sort");
       setShow(true)
-      return allitems;
+      setData(allitems.data)
     }
 
     const jjim=()=>{
@@ -19,13 +19,13 @@ export default function Sort() {
     const western=async ()=>{
       const western=await axios.get("/sort/western")
       setShow(true)
-      return western
+      setData(western.data)
     }
     
     const korea=async ()=>{
-      const western=await axios.get("/sort/western")
+      const korea=await axios.get("/sort/korea")
       setShow(true)
-      return western
+      setData(korea.data)
     }
     
     const japanese=async()=>{
@@ -37,12 +37,12 @@ export default function Sort() {
     const desert=async()=>{
       const desert=await axios.get("/sort/desert")
       setShow(true)
-      setData(desert)
+      setData(desert.data)
     }
     const fastfood=async ()=>{
       const fastfood=await axios.get("/sort/fastfood")
       setShow(true)
-      setData(fastfood)
+      setData(fastfood.data)
     }
    
     


### PR DESCRIPTION
### PR 타입
- [✅] 기능 추가
- [] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
seojeho->main

### 변경 사항
ui를 제외한 간단히 프론트와 백통신을 이루어진 서치기능, 카테고리 클릭시 관련 가게정보가 나오게 설정하였습니다.


### 테스트 결과

1)카테고리 클릭( 예)일식을 클릭할때)
![image](https://github.com/PDI-foodi/FrontEnd/assets/127959482/c8ba734a-24c3-4f09-8b20-fc4e7d45f779)

2)서치 기능(풍조만 검색했을때)

![image](https://github.com/PDI-foodi/FrontEnd/assets/127959482/dadbe69a-f06d-44c3-9f1d-3082e4c677b8)

3)카테고리클릭(랜덤으로 5개생성)

![ezgif com-video-to-gif-converter](https://github.com/PDI-foodi/FrontEnd/assets/127959482/59f8fb2c-24e8-4f8a-8a05-e8404a3363a6)






