### PR TITLE
회원가입 페이지 구현

### DIFF
--- a/frontend/src/components/login/Login.css
+++ b/frontend/src/components/login/Login.css
@@ -4,6 +4,7 @@
   align-items: center;
   justify-content: center;
   padding: 30px;
+  font-family: 'Pretendard', sans-serif;
 }
 
 .login > div {

--- a/frontend/src/components/login/Login.css
+++ b/frontend/src/components/login/Login.css
@@ -50,3 +50,12 @@ button.btn-primary {
 button.btn-primary:hover {
   background-color: #007836; /* 호버 시 배경 색상 변경 */
 }
+
+p.btn-signup {
+  margin-top: 10px;
+  font-size: 11px;
+  font-weight: lighter;
+  color: #949494;
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/frontend/src/components/login/Login.jsx
+++ b/frontend/src/components/login/Login.jsx
@@ -18,7 +18,7 @@ function Login() {
         });
         if (response.status === 200) {
           console.log("로그인 성공!");
-          document.cookie = `authToken=${response.data.authToken}; path=/; max-age=3600;`;
+          document.cookie = `authToken=${response.data.authToken};`;
           navigator(`/main`);
         } else {
           alert("로그인에 실패했습니다.");
@@ -52,9 +52,10 @@ function Login() {
           onChange={(e) => setPassword(e.target.value)}
         />
       </div>
-      <button type="button" class="btn btn-primary" onClick={loginHandling}>
+      <button type="button" className="btn btn-primary" onClick={loginHandling}>
         로그인
       </button>
+      <p className="btn-signup" onClick={()=>navigator(`/signup`)}>회원가입하기</p>
     </div>
   );
 }

--- a/frontend/src/components/navbar/Signup-Header.jsx
+++ b/frontend/src/components/navbar/Signup-Header.jsx
@@ -1,0 +1,24 @@
+import "./HeaderPage.css";
+import { useNavigate } from "react-router-dom";
+
+const HeaderPage = () => {
+  const navigate = useNavigate();
+
+  const handleCardClick = () => {
+    navigate(`/main`);
+  };
+  return (
+    <>
+      <div className="header">
+        <img
+          src="/img/pdlogo.png"
+          alt="프디푸디"
+          className="logo"
+          onClick={handleCardClick}
+        />
+      </div>
+      <div className="line"></div>
+    </>
+  );
+};
+export default HeaderPage;

--- a/frontend/src/components/signup/Signup.css
+++ b/frontend/src/components/signup/Signup.css
@@ -6,6 +6,7 @@
     align-items: center;
     flex-direction: column;
     margin-top: 90px;
+    font-family: 'Pretendard', sans-serif;
 }
 
 .signup-comment {

--- a/frontend/src/components/signup/Signup.css
+++ b/frontend/src/components/signup/Signup.css
@@ -1,0 +1,120 @@
+.signup-body {
+    height: 60vh;
+    display: flex;
+    justify-content: center;
+    text-align: center;
+    align-items: center;
+    flex-direction: column;
+    margin-top: 90px;
+}
+
+.signup-comment {
+    margin-bottom: 30px;
+}
+
+.signup-comment h1 {
+    font-size: 25px;
+    font-weight: bold;
+    margin-bottom: 20px;
+}
+
+.signup-comment p {
+    font-size: 17px;
+    color: #949494;
+    margin-bottom: 5px;
+}
+
+/*input section*/
+.signup-input > div {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    margin-bottom: 15px;
+  }
+
+.signup-input .signup-pwd-check, .signup-nickname {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 5px;
+    width: 100%;
+}
+  
+.signup-input label {
+    margin: 0;
+    width: 110px;
+    text-align: right;
+    margin-right: 10px;
+    font-weight: bolder;
+  }
+  
+.signup-input input {
+    flex-grow: 1;
+    width: 300px;
+    height: 40px;
+    padding: 8px 15px;
+    font-size: 16px;
+    border: none;
+    border-radius: 10px;
+    background-color: #d7ecd7;
+    box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
+  }
+
+.password-match {
+    color: #5770EE;
+}
+
+.password-mismatch {
+    color: #EE5757;
+}
+
+
+.signup-input .signup-pwd-check > div:nth-child(2){
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 5px;
+}
+
+.signup-pwd-check .password-message {
+  font-size: 15px;
+  padding-left: 10px;
+}
+
+.signup-input .signup-nickname > div:nth-child(2) {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 3px;
+}
+
+.signup-nickname .nickname-count {
+  font-size: 12px;
+  padding-left: 380px;
+  color: #949494;
+}
+
+button.btn-primary {
+    width: 130px;
+    padding: 7px 0;
+    margin-top: 20px;
+    font-size: 1rem;
+    font-weight: bold;
+    color: white;
+    background-color: #00a44b;
+    border: none;
+    border-radius: 20px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+    box-shadow: 2px 2px 3px rgba(0, 0, 0, 0.1);
+  }
+  
+  button.btn-primary:hover {
+    background-color: #007836; /* 호버 시 배경 색상 변경 */
+  }
+
+  .btn-primary:disabled {
+    background-color: #cccccc; /* 회색으로 설정 */
+    color: #666666; /* 글자색도 변경할 수 있음 */
+}

--- a/frontend/src/components/signup/Signup.jsx
+++ b/frontend/src/components/signup/Signup.jsx
@@ -1,0 +1,135 @@
+import React, {useState} from "react";
+import { useNavigate } from "react-router-dom";
+import axios from "axios";
+import "./Signup.css";
+
+function Signup() {
+    const [id, setId] = useState("");
+    const [password, setPassword] = useState("");
+    const [nickname, setNickname] = useState("");
+    const [nicknameCount, setNicknameCount] = useState(0);
+    const [passwordCheck, setPasswordCheck] = useState("");
+    const [passwordMessage, setPasswordMessage] = useState("");
+    const [messageClass, setMessageClass] = useState("password-mismatch");
+
+    const navigator = useNavigate();
+
+    const signupHandling = () => {
+        const signupData = async () => {
+            const response = await axios.post("/users/signup", {
+                id: id,
+                password: password,
+                nickname: nickname,
+            });
+            if (response.status === 201) {
+                console.log("회원가입 성공!");
+                navigator(`/`);
+            } else {
+                alert("회원가입에 실패했습니다.");
+            }
+        }
+        if (id === "") {
+            alert("아이디를 입력해주세요.");
+        }
+        else if (password === "") {
+            alert("비밀번호를 입력해주세요.");
+        }
+        else if (nickname === "") {
+            alert("닉네임을 입력해주세요.");
+        }
+        else if (messageClass === "password-mismatch") {
+            alert("비밀번호가 일치하지 않습니다.");
+        }
+        else {
+            signupData();
+        }
+        
+    };
+
+    const checkPassword = () => {
+        if (password === "" || passwordCheck === "") {
+            setPasswordMessage("");
+        } else if (password === passwordCheck) {
+            setPasswordMessage("비밀번호가 일치합니다!");
+            setMessageClass("password-match");
+        } else {
+            setPasswordMessage("비밀번호가 다릅니다!");
+            setMessageClass("password-mismatch");
+        }
+    }
+
+    const handleNicknameChange = (event) => {
+        const newNickname = event.target.value;
+        if (newNickname.length <= 10) {
+            setNickname(newNickname);
+            setNicknameCount(newNickname.length);
+        }
+    };
+
+    return (
+        <div className="signup-body">
+            <div className="signup-comment">
+                <h1>프디푸디에 오신 것을 환영합니다!</h1>
+                <p>회원가입하고</p>
+                <p>맛집 정보를 얻어보세요!</p>
+            </div>
+            <div className="signup-input">
+                <div className="signup-id">
+                    <label for="id">아이디</label>
+                    <input
+                        type="text"
+                        placeholder="pdazzang"
+                        name="id"
+                        value={id}
+                        onChange={(e) => setId(e.target.value)}
+                    />
+                </div>
+                <div className="signup-pwd">
+                    <label for="password">비밀번호</label>
+                    <input
+                        type="password"
+                        placeholder="********"
+                        name="password"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        onBlur={checkPassword}
+                    />
+                </div>
+                <div className="signup-pwd-check">
+                    <div>
+                        <label for="passwordCheck">비밀번호 확인</label>
+                        <input
+                        type="password"
+                        placeholder="********"
+                        name="passwordCheck"
+                        value={passwordCheck}
+                        onChange={(e) => setPasswordCheck(e.target.value)}
+                        onBlur={checkPassword}
+                    />
+                    </div>
+                    <div className={`password-message ${messageClass}`}>{passwordMessage}</div>
+                    
+                </div>
+                <div className="signup-nickname">
+                    <div>
+                        <label for="nickname">닉네임</label>
+                        <input
+                        type="text"
+                        placeholder="프디아짱"
+                        name="nickname"
+                        value={nickname}
+                        onChange={(e) => {handleNicknameChange(e)}}
+                        />
+                    </div>
+                    <div className="nickname-count">{nicknameCount}/10</div>
+                </div>
+                
+            </div>
+            <button type="button" className="btn btn-primary" onClick={signupHandling} disabled={messageClass !== "password-match"}>
+                    회원가입하기
+            </button>
+        </div>
+    );
+}
+
+export default Signup;

--- a/frontend/src/routes/signup/signupPage.jsx
+++ b/frontend/src/routes/signup/signupPage.jsx
@@ -1,4 +1,14 @@
+import HeaderPage from "../../components/navbar/Signup-Header";
+import FooterPage from "../../components/footer/FooterPage";
+import Signup from "../../components/signup/Signup";
+
 const SignupPage = () => {
-  return <div>signupPage</div>;
+  return (
+    <div>
+      <HeaderPage />
+      <Signup />
+      <FooterPage />
+    </div>
+  )
 };
 export default SignupPage;


### PR DESCRIPTION
### PR 타입
- [✔] 기능 추가
- [] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
hyeonju -> main

### 변경 사항
- 회원가입 페이지 UI를 구현했습니다.
- 회원가입 API와 연동했습니다.

### 테스트 결과
1. 로그인 페이지(초기 페이지, `localhost:3000`)에서 <회원가입하기>를 클릭합니다.
![image](https://github.com/PDI-foodi/FrontEnd/assets/140503027/2a524d3a-9ac6-461c-bf3b-f727cd007417)
2. 회원가입 페이지를 확인합니다.
![image](https://github.com/PDI-foodi/FrontEnd/assets/140503027/c328073a-3678-4bc2-bd53-41d26e44b582)

3. 아이디, 비밀번호, 닉네임을 입력하고, 활성화된 <회원가입하기>를 클릭합니다.
![image](https://github.com/PDI-foodi/FrontEnd/assets/140503027/1b126c3e-1ed2-410b-9c90-c3b1051622e9)
- 초기 화면은 <회원가입하기> 버튼이 비활성화된 상태입니다.
- 아이디를 입력하지 않고 <회원가입하기> 버튼을 누르면, "아이디를 입력하세요." 경고창이 팝업됩니다.
- 비밀번호 확인란에 일치하지 않는 비밀번호를 입력하면, "비밀번호가 다릅니다!"라는 파란 텍스트가 뜹니다.
- 비밀번호와 비밀번호 확인란에 기입한 비밀번호가 일치하면, "비밀번호가 일치합니다!"라는 빨간 텍스트가 뜹니다.
- 닉네임을 입력하지 않고 <회원가입하기> 버튼을 누르면, "닉네임을 입력하세요." 경고창이 팝업됩니다.
4. 회원가입이 완료되면 로그인 페이지로 이동합니다.