### PR TITLE
로그인, 회원가입 UI 수정 및 회원가입에서 에러 발생 시, <회원가입하기> 버튼 비활성화 기능 고도화

### DIFF
--- a/frontend/src/components/login/FindPwd.jsx
+++ b/frontend/src/components/login/FindPwd.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+function FindPwd() {
+  return (
+    <div>
+      <h1>비밀번호 찾기 페이지</h1>
+    </div>
+  );
+};
+
+export default FindPwd;

--- a/frontend/src/components/login/Login.css
+++ b/frontend/src/components/login/Login.css
@@ -15,7 +15,7 @@
   margin-bottom: 25px;
 }
 
-.login p {
+.login label {
   margin: 0;
   width: 70px;
   text-align: right;

--- a/frontend/src/components/login/Login.css
+++ b/frontend/src/components/login/Login.css
@@ -3,7 +3,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 30px;
+  padding-top: 30px;
   font-family: 'Pretendard', sans-serif;
 }
 
@@ -12,6 +12,9 @@
   align-items: center;
   width: 100%;
   max-width: 360px;
+}
+
+.login div:first-child {
   margin-bottom: 25px;
 }
 
@@ -34,9 +37,29 @@
   box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
 }
 
+.find-pwd {
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+  color: #949494;
+  text-decoration: underline;
+  font-size: 11px;
+  padding: 5px 5px;
+  cursor: pointer;
+}
+
+.find-pwd p {
+  transition: color 0.2s ease;
+}
+
+.find-pwd p:hover {
+  color: black;
+}
+
 button.btn-primary {
   width: 130px;
   padding: 7px 0;
+  margin-top: 0px;
   font-size: 1rem;
   font-weight: bold;
   color: white;
@@ -59,4 +82,9 @@ p.btn-signup {
   color: #949494;
   text-decoration: underline;
   cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+p.btn-signup:hover {
+  color: black;
 }

--- a/frontend/src/components/login/Login.jsx
+++ b/frontend/src/components/login/Login.jsx
@@ -35,19 +35,21 @@ function Login() {
   return (
     <div className="login">
       <div>
-        <p>아이디</p>
+        <label for="id">아이디</label>
         <input
           type="text"
           placeholder="pdazzang"
+          name="id"
           value={id}
           onChange={(e) => setId(e.target.value)}
         />
       </div>
       <div>
-        <p>비밀번호</p>
+        <label for="password">비밀번호</label>
         <input
           type="password"
           placeholder="********"
+          name="password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
         />

--- a/frontend/src/components/login/Login.jsx
+++ b/frontend/src/components/login/Login.jsx
@@ -54,6 +54,9 @@ function Login() {
           onChange={(e) => setPassword(e.target.value)}
         />
       </div>
+      <div className="find-pwd">
+        <p onClick={()=>navigator(`/find-pwd`)}>비밀번호찾기</p>
+      </div>
       <button type="button" className="btn btn-primary" onClick={loginHandling}>
         로그인
       </button>

--- a/frontend/src/components/login/Logo.css
+++ b/frontend/src/components/login/Logo.css
@@ -12,10 +12,6 @@
   z-index: 2;
 }
 
-.logo-container .logo img {
-  margin-bottom: 10px;
-}
-
 @media (min-width: 768px) {
   .logo-container .logo img {
     width: 300px;

--- a/frontend/src/components/login/Logo.css
+++ b/frontend/src/components/login/Logo.css
@@ -34,14 +34,14 @@
 
 @media (min-width: 768px) {
   .logo-container .line {
-    position: fixed;
-    top: 280px;
+    position: absolute;
+    top: 285px;
   }
 }
 
 @media (max-width: 768px) {
   .logo-container .line {
-    position: fixed;
+    position: absolute;
     top: 230px;
   }
 }

--- a/frontend/src/components/login/Logo.css
+++ b/frontend/src/components/login/Logo.css
@@ -13,14 +13,39 @@
 }
 
 .logo-container .logo img {
-  width: 200px;
+  margin-bottom: 10px;
+}
+
+@media (min-width: 768px) {
+  .logo-container .logo img {
+    width: 300px;
+  }
+}
+
+@media (max-width: 768px) {
+  .logo-container .logo img {
+    width: 200px;
+  }
 }
 
 .logo-container .line {
   width: 100%;
   height: 18px;
   background-color: #01a34b;
-  position: fixed;
-  top: 230px;
   z-index: 1;
+}
+
+
+@media (min-width: 768px) {
+  .logo-container .line {
+    position: fixed;
+    top: 280px;
+  }
+}
+
+@media (max-width: 768px) {
+  .logo-container .line {
+    position: fixed;
+    top: 230px;
+  }
 }

--- a/frontend/src/components/signup/Signup.css
+++ b/frontend/src/components/signup/Signup.css
@@ -13,9 +13,9 @@
     margin-bottom: 30px;
 }
 
-.signup-comment h1 {
+.signup-comment > h1 {
     font-size: 25px;
-    font-weight: bold;
+    font-weight: bolder;
     margin-bottom: 20px;
 }
 
@@ -80,7 +80,7 @@
 
 .signup-pwd-check .password-message {
   font-size: 15px;
-  padding-left: 10px;
+  padding-right: 30px;
 }
 
 .signup-input .signup-nickname > div:nth-child(2) {

--- a/frontend/src/components/signup/Signup.css
+++ b/frontend/src/components/signup/Signup.css
@@ -70,14 +70,6 @@
     color: #EE5757;
 }
 
-
-.signup-input .signup-pwd-check > div:nth-child(2){
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 5px;
-}
-
 .signup-pwd-check .password-message {
   font-size: 15px;
   padding-right: 30px;

--- a/frontend/src/components/signup/Signup.jsx
+++ b/frontend/src/components/signup/Signup.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React, {useEffect, useState} from "react";
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
 import "./Signup.css";
@@ -6,11 +6,13 @@ import "./Signup.css";
 function Signup() {
     const [id, setId] = useState("");
     const [password, setPassword] = useState("");
-    const [nickname, setNickname] = useState("");
-    const [nicknameCount, setNicknameCount] = useState(0);
     const [passwordCheck, setPasswordCheck] = useState("");
+    const [nickname, setNickname] = useState("");
+
+    const [nicknameCount, setNicknameCount] = useState(0);
     const [passwordMessage, setPasswordMessage] = useState("");
     const [messageClass, setMessageClass] = useState("password-mismatch");
+    const [signupAvailable, setSignupAvailable] = useState(false);
 
     const navigator = useNavigate();
 
@@ -49,6 +51,7 @@ function Signup() {
     const checkPassword = () => {
         if (password === "" || passwordCheck === "") {
             setPasswordMessage("");
+            setMessageClass("");
         } else if (password === passwordCheck) {
             setPasswordMessage("비밀번호가 일치합니다!");
             setMessageClass("password-match");
@@ -66,6 +69,18 @@ function Signup() {
         }
     };
 
+    useEffect(() => {
+        const checkSignupConditions = () => {
+            if (id !== "" && password !== "" && passwordCheck !== "" && nickname !== "" && messageClass === "password-match") {
+                setSignupAvailable(true);
+            } else {
+                setSignupAvailable(false);
+            }
+        };
+
+        checkSignupConditions();
+    }, [id, password, passwordCheck, nickname, messageClass]);
+
     return (
         <div className="signup-body">
             <div className="signup-comment">
@@ -81,7 +96,9 @@ function Signup() {
                         placeholder="pdazzang"
                         name="id"
                         value={id}
-                        onChange={(e) => setId(e.target.value)}
+                        onChange={(e) => {
+                            setId(e.target.value)
+                        }}
                     />
                 </div>
                 <div className="signup-pwd">
@@ -91,8 +108,10 @@ function Signup() {
                         placeholder="********"
                         name="password"
                         value={password}
-                        onChange={(e) => setPassword(e.target.value)}
-                        onBlur={checkPassword}
+                        onChange={(e) => {
+                            setPassword(e.target.value)
+                        }}
+                        onBlur={()=>checkPassword()}
                     />
                 </div>
                 <div className="signup-pwd-check">
@@ -103,8 +122,10 @@ function Signup() {
                         placeholder="********"
                         name="passwordCheck"
                         value={passwordCheck}
-                        onChange={(e) => setPasswordCheck(e.target.value)}
-                        onBlur={checkPassword}
+                        onChange={(e) => {
+                            setPasswordCheck(e.target.value)
+                        }}
+                        onBlur={()=>checkPassword()}
                     />
                     </div>
                     <div className={`password-message ${messageClass}`}>{passwordMessage}</div>
@@ -118,14 +139,16 @@ function Signup() {
                         placeholder="프디아짱"
                         name="nickname"
                         value={nickname}
-                        onChange={(e) => {handleNicknameChange(e)}}
+                        onChange={(e) => {
+                            handleNicknameChange(e)
+                        }}
                         />
                     </div>
                     <div className="nickname-count">{nicknameCount}/10</div>
                 </div>
                 
             </div>
-            <button type="button" className="btn btn-primary" onClick={signupHandling} disabled={messageClass !== "password-match"}>
+            <button type="button" className="btn btn-primary" onClick={signupHandling} disabled={signupAvailable === false}>
                     회원가입하기
             </button>
         </div>

--- a/frontend/src/routers/auth-router.jsx
+++ b/frontend/src/routers/auth-router.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import LoginPage from "../routes/login/loginPage";
 import SignupPage from "../routes/signup/signupPage";
+import FindPwdPage from "../routes/login/findPwdPage";
 
 const authRouter = [
   {
@@ -12,6 +13,10 @@ const authRouter = [
     path: "/signup",
     element: <SignupPage />,
   },
+  {
+    path: "/find-pwd",
+    element: <FindPwdPage />,
+  }
 ];
 
 export { authRouter };

--- a/frontend/src/routes/login/findPwdPage.jsx
+++ b/frontend/src/routes/login/findPwdPage.jsx
@@ -1,0 +1,11 @@
+import FindPwd from '../../components/login/FindPwd';
+
+const FindPwdPage = () => {
+    return (
+        <div>
+        <FindPwd />
+        </div>
+    );
+};
+
+export default FindPwdPage;


### PR DESCRIPTION
### PR 타입
- [] 기능 추가
- [✔] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
hyeonju -> main

### 변경 사항
- 로그인, 회원가입 UI를 일부 수정했습니다.(마진, 패딩 등)
- 로그인 화면에 <비밀번호찾기> 버튼을 추가했습니다.
- 회원가입에서 아래와 같은 에러 발생 시, <회원가입하기> 버튼이 비활성화되는 기능을 useEffect()를 사용하여 고도화했습니다.
-> 아이디, 비밀번호, 비밀번호 확인, 닉네임 중 하나라도 빈칸인 경우
-> 비밀번호와 비밀번호 확인란에 기입된 비밀번호가 일치하지 않는 경우

### 테스트 결과
1. 로그인 페이지의 반응형을 확인합니다.
2. 회원가입 페이지에서 아이디, 비밀번호, 비밀번호 확인, 닉네임을 입력하며 <회원가입하기> 버튼이 비활성화->활성화되는 것을 확인합니다.
3. 아이디(혹은 비밀번호, 비밀번호 확인, 닉네임)를 지워 <회원가입하기> 버튼이 활성화->비활성화되는 것을 확인합니다.
4. 모두 입력하되, 비밀번호와 비밀번호 확인을 다르게 입력하여 <회원가입하기> 버튼이 비활성화되는 것을 확인합니다.
