### PR TITLE
비밀번호 찾기 및 비밀번호 재설정 모달 구현

### DIFF
--- a/frontend/src/components/login/FindPwd.css
+++ b/frontend/src/components/login/FindPwd.css
@@ -1,0 +1,130 @@
+.find-pwd-body {
+  height: 60vh;
+  display: flex;
+  justify-content: center;
+  text-align: center;
+  align-items: center;
+  flex-direction: column;
+  margin-top: 90px;
+  font-family: "Pretendard", sans-serif;
+}
+
+.find-pwd-comment {
+  margin-bottom: 30px;
+}
+
+.find-pwd-comment > h1 {
+  font-size: 25px;
+  font-weight: bolder;
+  margin-bottom: 20px;
+}
+
+.find-pwd-comment > p {
+  font-size: 17px;
+  color: #949494;
+  margin-bottom: 5px;
+}
+
+.find-pwd-input > div {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  margin-bottom: 15px;
+}
+
+.find-pwd-input label {
+  margin: 0;
+  text-align: right;
+  margin-right: 10px;
+  font-weight: bolder;
+}
+
+.find-pwd-input input {
+  flex-grow: 1;
+  width: 300px;
+  height: 40px;
+  padding: 8px 15px;
+  font-size: 16px;
+  border: none;
+  border-radius: 10px;
+  background-color: #d7ecd7;
+  box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+/* find-pwd-modal */
+
+.find-pwd-modal-background {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.find-pwd-modal-content {
+  background: white;
+  padding: 35px;
+  border-radius: 44px;
+  width: 450px;
+}
+
+.find-pwd-modal-header {
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  margin-bottom: 20px;
+}
+
+.find-pwd-modal-header p {
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.find-pwd-modal-body {
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+}
+
+.find-pwd-modal-body > div {
+  font-size: 16px;
+  margin-bottom: 10px;
+}
+
+.find-pwd-modal-body > div > label {
+  text-align: right;
+  font-weight: bold;
+  width: 120px;
+  padding-right: 10px;
+}
+
+.find-pwd-modal-body > div > input {
+  flex-grow: 1;
+  width: 250px;
+  height: 40px;
+  padding: 8px 15px;
+  font-size: 16px;
+  border: none;
+  border-radius: 10px;
+  background-color: #d7ecd7;
+  box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
+  margin-bottom: 5px;
+}
+
+.password-match {
+  color: #5770ee;
+}
+
+.password-mismatch {
+  color: #ee5757;
+}
+
+.find-pwd-modal-content > button {
+  margin-top: 20px;
+  margin-left: 65%;
+}

--- a/frontend/src/components/login/FindPwd.jsx
+++ b/frontend/src/components/login/FindPwd.jsx
@@ -1,11 +1,183 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import axios from "axios";
+import "./FindPwd.css";
 
 function FindPwd() {
+  const [id, setId] = useState("");
+  const [nickname, setNickname] = useState("");
+  const [findAvailable, setFindAvailable] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const findPwdHandling = () => {
+    const findPwdData = async () => {
+      try {
+        const response = await axios.post("/users/find-pwd", {
+          id: id,
+          nickname: nickname,
+        });
+        console.log(response.data);
+        if (response.status === 200) {
+          setModalOpen(true);
+        } else {
+          alert("비밀번호 찾기에 실패했습니다.");
+        }
+      } catch (error) {
+        if (error.response.status === 404) {
+          alert("아이디를 확인해주세요.");
+        } else if (error.response.status === 400) {
+          alert("닉네임을 확인해주세요.");
+        } else {
+          alert("비밀번호 찾기에 실패했습니다.");
+        }
+        console.error("비밀번호 찾기 실패: ", error);
+      }
+    };
+
+    findPwdData();
+  };
+
+  useEffect(() => {
+    const checkConditions = () => {
+      if (id !== "" && nickname !== "") {
+        setFindAvailable(true);
+      } else {
+        setFindAvailable(false);
+      }
+    };
+
+    checkConditions();
+  }, [id, nickname]);
+
   return (
-    <div>
-      <h1>비밀번호 찾기 페이지</h1>
+    <div className="find-pwd-body">
+      <div className="find-pwd-comment">
+        <h1>비밀번호를 잊어버리셨나요?</h1>
+        <p>아이디와 닉네임을 입력해주세요!</p>
+      </div>
+      <div className="find-pwd-input">
+        <div>
+          <label for="id">아이디</label>
+          <input
+            type="text"
+            placeholder="pdazzang"
+            name="id"
+            onChange={(e) => setId(e.target.value)}
+          />
+        </div>
+        <div>
+          <label for="nickname">닉네임</label>
+          <input
+            type="text"
+            placeholder="프디아짱"
+            name="nickname"
+            onChange={(e) => setNickname(e.target.value)}
+          />
+        </div>
+      </div>
+      <button
+        type="button"
+        className="btn btn-primary"
+        onClick={findPwdHandling}
+        disabled={findAvailable === false}
+      >
+        비밀번호찾기
+      </button>
+      {modalOpen && (
+        <PasswordResetModal
+          close={() => setModalOpen(false)}
+          id={id}
+          nickname={nickname}
+        />
+      )}
     </div>
   );
-};
+}
+
+function PasswordResetModal({ close, id, nickname }) {
+  const [newPassword, setNewPassword] = useState("");
+  const [newPasswordCheck, setNewPasswordCheck] = useState("");
+  const [passwordMatch, setPasswordMatch] = useState("");
+  const [passwordMessage, setPasswordMessage] = useState("");
+
+  const navigator = useNavigate();
+
+  const resetPassword = async () => {
+    const resetData = async () => {
+      try {
+        const response = await axios.put("/users/reset-pwd", {
+          id: id,
+          password: newPassword,
+        });
+        if (response.status === 200) {
+          alert("비밀번호가 성공적으로 변경되었습니다.");
+          navigator(`/`);
+        } else {
+          alert("비밀번호 변경에 실패했습니다.");
+        }
+      } catch (error) {
+        alert("비밀번호 변경에 실패했습니다.");
+        console.error("비밀번호 변경 실패: ", error);
+      }
+    };
+
+    resetData();
+  };
+
+  useEffect(() => {
+    if (newPassword === "" || newPasswordCheck === "") {
+      setPasswordMatch("");
+      setPasswordMessage("");
+    } else if (newPassword === newPasswordCheck) {
+      setPasswordMatch("password-match");
+      setPasswordMessage("비밀번호가 일치합니다!");
+    } else {
+      setPasswordMatch("password-mismatch");
+      setPasswordMessage("비밀번호가 다릅니다!");
+    }
+  }, [newPassword, newPasswordCheck]);
+
+  return (
+    <div className="find-pwd-modal-background">
+      <div className="find-pwd-modal-content">
+        <div className="find-pwd-modal-header">
+          <p>{nickname}님!</p>
+          <p>비밀번호를 재설정해주세요!</p>
+        </div>
+        <div className="find-pwd-modal-body">
+          <div>
+            <label for="newPassword">새 비밀번호</label>
+            <input
+              type="password"
+              placeholder="********"
+              name="newPassword"
+              onChange={(e) => setNewPassword(e.target.value)}
+            />
+          </div>
+          <div className="find-pwd-password-check">
+            <label for="newPasswordCheck">새 비밀번호 확인</label>
+            <input
+              type="password"
+              placeholder="********"
+              name="newPasswordCheck"
+              onChange={(e) => setNewPasswordCheck(e.target.value)}
+            />
+            <div className={`password-message ${passwordMatch}`}>
+              {passwordMessage}
+            </div>
+          </div>
+        </div>
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={resetPassword}
+          disabled={passwordMatch !== "password-match"}
+        >
+          비밀번호 변경
+        </button>
+      </div>
+    </div>
+  );
+}
 
 export default FindPwd;

--- a/frontend/src/components/login/Logo.css
+++ b/frontend/src/components/login/Logo.css
@@ -5,7 +5,7 @@
   margin-top: 150px;
 }
 
-.logo-container .logo {
+.logo-container .login-logo {
   width: 100%;
   height: auto;
   position: relative;
@@ -13,13 +13,13 @@
 }
 
 @media (min-width: 768px) {
-  .logo-container .logo img {
+  .logo-container .login-logo img {
     width: 300px;
   }
 }
 
 @media (max-width: 768px) {
-  .logo-container .logo img {
+  .logo-container .login-logo img {
     width: 200px;
   }
 }
@@ -30,7 +30,6 @@
   background-color: #01a34b;
   z-index: 1;
 }
-
 
 @media (min-width: 768px) {
   .logo-container .line {

--- a/frontend/src/components/login/Logo.jsx
+++ b/frontend/src/components/login/Logo.jsx
@@ -4,7 +4,7 @@ import "./Logo.css";
 function Logo() {
   return (
     <div className="logo-container">
-      <div className="logo">
+      <div className="login-logo">
         <img src="/img/pdifoodi-logo.png" alt="logo" />
       </div>
       <div className="line"></div>

--- a/frontend/src/components/signup/Signup.css
+++ b/frontend/src/components/signup/Signup.css
@@ -1,85 +1,86 @@
 .signup-body {
-    height: 60vh;
-    display: flex;
-    justify-content: center;
-    text-align: center;
-    align-items: center;
-    flex-direction: column;
-    margin-top: 90px;
-    font-family: 'Pretendard', sans-serif;
+  height: 60vh;
+  display: flex;
+  justify-content: center;
+  text-align: center;
+  align-items: center;
+  flex-direction: column;
+  margin-top: 90px;
+  font-family: "Pretendard", sans-serif;
 }
 
 .signup-comment {
-    margin-bottom: 30px;
+  margin-bottom: 30px;
 }
 
 .signup-comment > h1 {
-    font-size: 25px;
-    font-weight: bolder;
-    margin-bottom: 20px;
+  font-size: 25px;
+  font-weight: bolder;
+  margin-bottom: 20px;
 }
 
 .signup-comment p {
-    font-size: 17px;
-    color: #949494;
-    margin-bottom: 5px;
+  font-size: 17px;
+  color: #949494;
+  margin-bottom: 5px;
 }
 
 /*input section*/
 .signup-input > div {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 100%;
-    margin-bottom: 15px;
-  }
-
-.signup-input .signup-pwd-check, .signup-nickname {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 5px;
-    width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  margin-bottom: 15px;
 }
-  
+
+.signup-input .signup-pwd-check,
+.signup-nickname {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  width: 100%;
+}
+
 .signup-input label {
-    margin: 0;
-    width: 110px;
-    text-align: right;
-    margin-right: 10px;
-    font-weight: bolder;
-  }
-  
+  margin: 0;
+  width: 110px;
+  text-align: right;
+  margin-right: 10px;
+  font-weight: bolder;
+}
+
 .signup-input input {
-    flex-grow: 1;
-    width: 300px;
-    height: 40px;
-    padding: 8px 15px;
-    font-size: 16px;
-    border: none;
-    border-radius: 10px;
-    background-color: #d7ecd7;
-    box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
-  }
+  flex-grow: 1;
+  width: 300px;
+  height: 40px;
+  padding: 8px 15px;
+  font-size: 16px;
+  border: none;
+  border-radius: 10px;
+  background-color: #d7ecd7;
+  box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
+}
 
 .password-match {
-    color: #5770EE;
+  color: #5770ee;
 }
 
 .password-mismatch {
-    color: #EE5757;
+  color: #ee5757;
 }
 
 .signup-pwd-check .password-message {
   font-size: 15px;
-  padding-right: 30px;
+  /* padding-right: 30px; */
 }
 
 .signup-input .signup-nickname > div:nth-child(2) {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: 3px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 3px;
 }
 
 .signup-nickname .nickname-count {
@@ -89,25 +90,25 @@
 }
 
 button.btn-primary {
-    width: 130px;
-    padding: 7px 0;
-    margin-top: 20px;
-    font-size: 1rem;
-    font-weight: bold;
-    color: white;
-    background-color: #00a44b;
-    border: none;
-    border-radius: 20px;
-    cursor: pointer;
-    transition: background-color 0.3s ease;
-    box-shadow: 2px 2px 3px rgba(0, 0, 0, 0.1);
-  }
-  
-  button.btn-primary:hover {
-    background-color: #007836; /* 호버 시 배경 색상 변경 */
-  }
+  width: 130px;
+  padding: 7px 0;
+  margin-top: 20px;
+  font-size: 1rem;
+  font-weight: bold;
+  color: white;
+  background-color: #00a44b;
+  border: none;
+  border-radius: 20px;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+  box-shadow: 2px 2px 3px rgba(0, 0, 0, 0.1);
+}
 
-  .btn-primary:disabled {
-    background-color: #cccccc; /* 회색으로 설정 */
-    color: #666666; /* 글자색도 변경할 수 있음 */
+button.btn-primary:hover {
+  background-color: #007836; /* 호버 시 배경 색상 변경 */
+}
+
+.btn-primary:disabled {
+  background-color: #cccccc; /* 회색으로 설정 */
+  color: #666666; /* 글자색도 변경할 수 있음 */
 }

--- a/frontend/src/routes/login/findPwdPage.jsx
+++ b/frontend/src/routes/login/findPwdPage.jsx
@@ -1,11 +1,15 @@
-import FindPwd from '../../components/login/FindPwd';
+import HeaderPage from "../../components/navbar/Signup-Header";
+import FooterPage from "../../components/footer/FooterPage";
+import FindPwd from "../../components/login/FindPwd";
 
 const FindPwdPage = () => {
-    return (
-        <div>
-        <FindPwd />
-        </div>
-    );
+  return (
+    <div>
+      <HeaderPage />
+      <FindPwd />
+      <FooterPage />
+    </div>
+  );
 };
 
 export default FindPwdPage;


### PR DESCRIPTION
### PR 타입
- [✔] 기능 추가
- [] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
hyeonju -> main

### 변경 사항
- 로그인 페이지의 <비밀번호 찾기> 클릭 시, 랜더링되는 비밀번호 찾기 페이지를 구현했습니다.
- 비밀번호 찾기 페이지에서 사용자가 입력한 id와 nickname에 해당하는 사용자가 있는 경우, 비밀번호 재설정 모달이 뜨게 했습니다.

### 테스트 결과
1. 로그인 페이지에서 비밀번호 입력란 하단의 <비밀번호 찾기> 버튼을 클릭합니다.
![image](https://github.com/PDI-foodi/FrontEnd/assets/140503027/7bcce4ad-0ede-4d6d-84b8-32d6d2dc8bb2)

2. 비밀번호 찾기 페이지를 확인합니다.
![image](https://github.com/PDI-foodi/FrontEnd/assets/140503027/847a7cf6-ddf4-4c74-b507-a35f2720a298)

3. 아이디와 닉네임 입력란에 아래와 같이 입력하고 <비밀번호찾기> 버튼이 활성화되는 것을 확인합니다.
```
id: "dlguswn"
nickname: "새로운 스키마 테스트중"
```
![image](https://github.com/PDI-foodi/FrontEnd/assets/140503027/700e5b7c-763e-4c39-b761-a542590b1bf9)

4. <비밀번호찾기> 버튼을 클릭하여 모달창이 뜨는 것을 확인합니다.
![image](https://github.com/PDI-foodi/FrontEnd/assets/140503027/3a7168ad-058f-4a0e-86ce-66192ce808f6)

5. 새 비밀번호와 새 비밀번호 확인 입력란에 동일한 문자열을 입력하고 <비밀번호 변경> 버튼이 활성화되는 것을 확인합니다.
![image](https://github.com/PDI-foodi/FrontEnd/assets/140503027/8394308b-e657-4e30-ae5f-f0fa1eeaab7c)
(새 비밀번호와 새 비밀번호 확인에 입력된 값이 다르면 "비밀번호가 다릅니다!"라는 빨간 텍스트가 뜨고, 같으면 "비밀번호가 일치합니다!"라는 파란 텍스트가 뜹니다.)

6. <비밀번호 변경> 버튼을 클릭하고 "비밀번호가 성공적으로 변경되었습니다!" 팝업창을 확인합니다.
![image](https://github.com/PDI-foodi/FrontEnd/assets/140503027/a6757e40-130e-42ee-a97d-b55fd00a9ca5)

7. <확인> 버튼을 클릭하면 로그인 페이지로 이동합니다.